### PR TITLE
feat: AI image generation plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 ```text
 .
 ├── cmd/napcat-jm-go/        # 标准 Go 入口
-├── internal/app/            # 核心实现（HTTP事件、命令、下载、识图、发送）
+├── internal/app/            # 核心实现（HTTP事件、命令、下载、识图、发送、AI画图）
+├── internal/aiimage/        # AI 画图 OpenAI 兼容 API 客户端
 ├── configs/
 │   ├── config.example.yml   # 示例配置
 │   └── option.yml           # jmcomic 配置
@@ -62,9 +63,18 @@
 
 ### 2.3 识图联动
 - 识图成功后，会自动提取标题关键词（含中日文片段）并走 `/jm search` 同款检索逻辑
-- 命中后自动写入待确认队列，回复“确认”即可下载
+- 命中后自动写入待确认队列，回复"确认"即可下载
 
-### 2.3 发送策略
+### 2.4 AI 画图
+- `image on`：开启 AI 画图（管理员）
+- `image off`：关闭 AI 画图
+- `image2 <提示词>`：生成图片
+- **图生图**：回复带图片的消息发送 `image2 <提示词>`，可将回复的图片作为参考图
+- 失败自动重试最多 3 次
+- 配置项：`ai_image_enabled`、`ai_image_api_key`、`ai_image_base_url`、`ai_image_model`、`ai_image_size`、`ai_image_timeout`、`ai_image_max_retries`
+- API Key 支持 `AI_IMAGE_API_KEY` 环境变量回退，避免写入配置文件
+
+### 2.5 发送策略
 - 普通消息默认纯文本
 - 批量任务通知可按 `reply_as_card` 使用转发卡片（仅批量场景）
 
@@ -163,6 +173,15 @@ docker compose down
 - `./manga -> /app/manga`
 - `./cbz -> /app/cbz`
 - `./logs -> /app/logs`
+
+**AI 画图配置**：
+- `ai_image_enabled`：是否启用 AI 画图（默认 `false`，管理员发送 `image on` 后自动激活）
+- `ai_image_api_key`：API 密钥（建议使用环境变量 `AI_IMAGE_API_KEY`）
+- `ai_image_base_url`：OpenAI 兼容 API 地址（默认 `http://47.104.6.123:3000/v1`）
+- `ai_image_model`：模型名称（默认 `gpt-image-2`）
+- `ai_image_size`：图片尺寸（默认 `1024x1024`）
+- `ai_image_timeout`：请求超时秒数（默认 `120`）
+- `ai_image_max_retries`：失败重试次数（默认 `3`）
 
 ## 5. NapCat 配置（必须）
 

--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -112,3 +112,12 @@ bika_base_url: "https://api.go2778.com/"  # Bika API 地址（默认使用代理
 bika_token: ""               # Bika 登录 Token（登录后获取，可选）
 bika_quality: "original"     # 图片画质：original / high / middle / low
 bika_proxy: ""               # HTTP 代理（如 socks5://127.0.0.1:1080）
+
+# AI 生图配置（可选）
+ai_image_enabled: false              # 是否启用 AI 生图功能
+ai_image_base_url: "https://api.openai.com/v1"  # OpenAI 兼容 API 地址
+ai_image_api_key: ""                 # API Key（也可通过环境变量 AI_IMAGE_API_KEY 设置）
+ai_image_model: "dall-e-3"           # 模型名
+ai_image_size: "1024x1024"           # 图片尺寸
+ai_image_timeout_seconds: 120        # 请求超时（秒）
+ai_image_max_retries: 3              # 失败重试次数

--- a/internal/aiimage/aiimage.go
+++ b/internal/aiimage/aiimage.go
@@ -47,7 +47,7 @@ func generateImageOnce(cfg Config, prompt string) (*Result, error) {
 		"prompt":          prompt,
 		"n":               1,
 		"size":            cfg.Size,
-		"response_format": "url",
+		"response_format": "b64_json",
 	}
 
 	b, _ := json.Marshal(body)
@@ -108,7 +108,7 @@ func editImageOnce(cfg Config, prompt string, imageBytes []byte) (*Result, error
 	_ = w.WriteField("prompt", prompt)
 	_ = w.WriteField("size", cfg.Size)
 	_ = w.WriteField("n", "1")
-	_ = w.WriteField("response_format", "url")
+	_ = w.WriteField("response_format", "b64_json")
 
 	fw, err := w.CreateFormFile("image", "image.png")
 	if err != nil {

--- a/internal/aiimage/aiimage.go
+++ b/internal/aiimage/aiimage.go
@@ -1,0 +1,175 @@
+package aiimage
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	BaseURL    string
+	APIKey     string
+	Model      string
+	Size       string
+	Timeout    time.Duration
+	MaxRetries int
+}
+
+type Result struct {
+	ImageURL string
+	B64JSON  string
+}
+
+func GenerateImage(cfg Config, prompt string) (*Result, error) {
+	var result *Result
+	var lastErr error
+	for i := 0; i < cfg.MaxRetries; i++ {
+		result, lastErr = generateImageOnce(cfg, prompt)
+		if lastErr == nil {
+			return result, nil
+		}
+		log.Printf("AI generate attempt %d/%d failed: %v", i+1, cfg.MaxRetries, lastErr)
+	}
+	return nil, fmt.Errorf("AI 生图失败（已重试%d次）：%s", cfg.MaxRetries-1, briefError(lastErr))
+}
+
+func generateImageOnce(cfg Config, prompt string) (*Result, error) {
+	url := strings.TrimRight(cfg.BaseURL, "/") + "/images/generations"
+
+	body := map[string]any{
+		"model":           cfg.Model,
+		"prompt":          prompt,
+		"n":               1,
+		"size":            cfg.Size,
+		"response_format": "url",
+	}
+
+	b, _ := json.Marshal(body)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+
+	client := &http.Client{Timeout: cfg.Timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API status %d", resp.StatusCode)
+	}
+
+	var apiResp struct {
+		Data []struct {
+			URL     string `json:"url"`
+			B64JSON string `json:"b64_json"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &apiResp); err != nil {
+		return nil, fmt.Errorf("parse response failed")
+	}
+	if len(apiResp.Data) == 0 {
+		return nil, fmt.Errorf("API returned empty data")
+	}
+	return &Result{ImageURL: apiResp.Data[0].URL, B64JSON: apiResp.Data[0].B64JSON}, nil
+}
+
+func EditImage(cfg Config, prompt string, imageBytes []byte) (*Result, error) {
+	var result *Result
+	var lastErr error
+	for i := 0; i < cfg.MaxRetries; i++ {
+		result, lastErr = editImageOnce(cfg, prompt, imageBytes)
+		if lastErr == nil {
+			return result, nil
+		}
+		log.Printf("AI edit attempt %d/%d failed: %v", i+1, cfg.MaxRetries, lastErr)
+	}
+	return nil, fmt.Errorf("AI 图生图失败（已重试%d次）：%s", cfg.MaxRetries-1, briefError(lastErr))
+}
+
+func editImageOnce(cfg Config, prompt string, imageBytes []byte) (*Result, error) {
+	url := strings.TrimRight(cfg.BaseURL, "/") + "/images/edits"
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	_ = w.WriteField("model", cfg.Model)
+	_ = w.WriteField("prompt", prompt)
+	_ = w.WriteField("size", cfg.Size)
+	_ = w.WriteField("n", "1")
+	_ = w.WriteField("response_format", "url")
+
+	fw, err := w.CreateFormFile("image", "image.png")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := fw.Write(imageBytes); err != nil {
+		return nil, err
+	}
+	_ = w.Close()
+
+	req, err := http.NewRequest(http.MethodPost, url, &buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+
+	client := &http.Client{Timeout: cfg.Timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API status %d", resp.StatusCode)
+	}
+
+	var apiResp struct {
+		Data []struct {
+			URL     string `json:"url"`
+			B64JSON string `json:"b64_json"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &apiResp); err != nil {
+		return nil, fmt.Errorf("parse response failed")
+	}
+	if len(apiResp.Data) == 0 {
+		return nil, fmt.Errorf("API returned empty data")
+	}
+	return &Result{ImageURL: apiResp.Data[0].URL, B64JSON: apiResp.Data[0].B64JSON}, nil
+}
+
+func briefError(err error) string {
+	if err == nil {
+		return "未知错误"
+	}
+	msg := strings.TrimSpace(err.Error())
+	if msg == "" {
+		return "未知错误"
+	}
+	if idx := strings.Index(msg, "sk-"); idx >= 0 {
+		end := idx + 20
+		if end > len(msg) {
+			end = len(msg)
+		}
+		msg = msg[:idx] + "sk-***" + msg[end:]
+	}
+	if len([]rune(msg)) > 200 {
+		msg = string([]rune(msg)[:200]) + "..."
+	}
+	return msg
+}

--- a/internal/app/ai_image.go
+++ b/internal/app/ai_image.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -91,9 +90,18 @@ func (a *App) handleAIImageCommand(rawMessage string, data map[string]any, messa
 		return true
 	}
 
-	imageRef := result.ImageURL
-	if imageRef == "" && result.B64JSON != "" {
-		imageRef = "base64://" + result.B64JSON
+	var imageRef string
+	if result.B64JSON != "" {
+		imageRef = "base64://" + strings.TrimPrefix(result.B64JSON, "data:image/")
+		if idx := strings.Index(imageRef, ","); idx > 0 {
+			imageRef = "base64://" + imageRef[idx+1:]
+		}
+	} else if strings.HasPrefix(result.ImageURL, "data:") {
+		if idx := strings.Index(result.ImageURL, ","); idx > 0 {
+			imageRef = "base64://" + result.ImageURL[idx+1:]
+		}
+	} else {
+		imageRef = result.ImageURL
 	}
 	if imageRef == "" {
 		msg := "AI 画图返回为空"

--- a/internal/app/ai_image.go
+++ b/internal/app/ai_image.go
@@ -1,0 +1,156 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"napcat-jm-go/internal/aiimage"
+)
+
+func (a *App) handleAIImageCommand(rawMessage string, data map[string]any, messageType string, groupID, userID int64) bool {
+	m := mustMatch(`^(?:/)?image2\s+(.+)$`, rawMessage)
+	if m == nil {
+		return false
+	}
+	prompt := strings.TrimSpace(m[1])
+	if prompt == "" {
+		return false
+	}
+
+	cfg := a.currentConfig()
+	if !cfg.AIImageEnabled {
+		a.sendMessage(messageType, groupID, userID, "AI 生图功能未启用")
+		return true
+	}
+	if cfg.AIImageAPIKey == "" {
+		a.sendMessage(messageType, groupID, userID, "AI 生图未配置 API Key")
+		return true
+	}
+
+	aiCfg := aiimage.Config{
+		BaseURL:    cfg.AIImageBaseURL,
+		APIKey:     cfg.AIImageAPIKey,
+		Model:      cfg.AIImageModel,
+		Size:       cfg.AIImageSize,
+		Timeout:    time.Duration(cfg.AIImageTimeout) * time.Second,
+		MaxRetries: cfg.AIImageMaxRetries,
+	}
+
+	a.sendMessage(messageType, groupID, userID, "正在生成图片...")
+
+	imageBytes, _ := a.extractAIImageBytes(data)
+
+	var result *aiimage.Result
+	var err error
+
+	if len(imageBytes) > 0 {
+		result, err = aiimage.EditImage(aiCfg, prompt, imageBytes)
+	} else {
+		result, err = aiimage.GenerateImage(aiCfg, prompt)
+	}
+
+	if err != nil {
+		if messageType == "group" && groupID > 0 {
+			a.bot.SendGroupMsgWithAtText(groupID, userID, err.Error())
+		} else {
+			a.bot.SendPrivateMessage(userID, err.Error())
+		}
+		return true
+	}
+
+	imageRef := result.ImageURL
+	if imageRef == "" && result.B64JSON != "" {
+		imageRef = "base64://" + result.B64JSON
+	}
+	if imageRef == "" {
+		msg := "AI 生图返回为空"
+		if messageType == "group" && groupID > 0 {
+			a.bot.SendGroupMsgWithAtText(groupID, userID, msg)
+		} else {
+			a.bot.SendPrivateMessage(userID, msg)
+		}
+		return true
+	}
+
+	if messageType == "group" && groupID > 0 {
+		a.bot.SendGroupMsgWithAtAndImage(groupID, userID, imageRef)
+	} else {
+		a.bot.SendPrivateMsgWithImage(userID, imageRef)
+	}
+	return true
+}
+
+func (a *App) extractAIImageBytes(data map[string]any) ([]byte, error) {
+	replyID := extractReplyMessageID(data)
+	if replyID > 0 {
+		msgData, err := a.bot.GetMsg(replyID)
+		if err == nil && msgData != nil {
+			sources := extractSoutuImageSourcesFromEvent(msgData)
+			for _, src := range sources {
+				if src.ImageURL != "" {
+					return downloadImageBytes(src.ImageURL)
+				}
+				if len(src.ImageBytes) > 0 {
+					return src.ImageBytes, nil
+				}
+			}
+		}
+	}
+
+	sources := extractSoutuImageSourcesFromEvent(data)
+	for _, src := range sources {
+		if src.ImageURL != "" {
+			return downloadImageBytes(src.ImageURL)
+		}
+		if len(src.ImageBytes) > 0 {
+			return src.ImageBytes, nil
+		}
+	}
+
+	refs := extractSoutuImageFileRefsFromEvent(data)
+	for _, ref := range refs {
+		u, err := a.bot.GetImageURL(ref)
+		if err == nil && u != "" {
+			return downloadImageBytes(u)
+		}
+	}
+
+	return nil, nil
+}
+
+func extractReplyMessageID(data map[string]any) int64 {
+	msg, ok := data["message"].([]any)
+	if !ok {
+		return 0
+	}
+	for _, seg := range msg {
+		m, ok := seg.(map[string]any)
+		if !ok || toString(m["type"]) != "reply" {
+			continue
+		}
+		dm := mapGet(m, "data")
+		return toInt64(dm["id"])
+	}
+	return 0
+}
+
+func downloadImageBytes(imageURL string) ([]byte, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, imageURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download image status %d", resp.StatusCode)
+	}
+	return 	io.ReadAll(resp.Body)
+}

--- a/internal/app/ai_image.go
+++ b/internal/app/ai_image.go
@@ -12,6 +12,35 @@ import (
 )
 
 func (a *App) handleAIImageCommand(rawMessage string, data map[string]any, messageType string, groupID, userID int64) bool {
+	// image on / off / help
+	if m := mustMatch(`^(?:/)?image\s+(on|off|help)$`, rawMessage); m != nil {
+		switch m[1] {
+		case "on":
+			if !a.requireAdmin(messageType, groupID, userID, "仅管理员可开启 AI 画图") {
+				return true
+			}
+			a.cfgMu.Lock()
+			a.cfg.AIImageEnabled = true
+			a.cfgMu.Unlock()
+			a.saveConfig()
+			a.sendMessage(messageType, groupID, userID, "AI 画图功能已开启，使用 image2 <提示词> 生成图片")
+			return true
+		case "off":
+			if !a.requireAdmin(messageType, groupID, userID, "仅管理员可关闭 AI 画图") {
+				return true
+			}
+			a.cfgMu.Lock()
+			a.cfg.AIImageEnabled = false
+			a.cfgMu.Unlock()
+			a.saveConfig()
+			a.sendMessage(messageType, groupID, userID, "AI 画图功能已关闭")
+			return true
+		case "help":
+			a.sendMessage(messageType, groupID, userID, "AI 画图使用说明：\n1) image on - 开启画图功能\n2) image off - 关闭画图功能\n3) image2 <提示词> - 生成图片\n4) 引用图片后 image2 <提示词> - 图生图")
+			return true
+		}
+	}
+
 	m := mustMatch(`^(?:/)?image2\s+(.+)$`, rawMessage)
 	if m == nil {
 		return false
@@ -23,11 +52,11 @@ func (a *App) handleAIImageCommand(rawMessage string, data map[string]any, messa
 
 	cfg := a.currentConfig()
 	if !cfg.AIImageEnabled {
-		a.sendMessage(messageType, groupID, userID, "AI 生图功能未启用")
+		a.sendMessage(messageType, groupID, userID, "AI 画图功能未开启，请发送 image on 开启")
 		return true
 	}
 	if cfg.AIImageAPIKey == "" {
-		a.sendMessage(messageType, groupID, userID, "AI 生图未配置 API Key")
+		a.sendMessage(messageType, groupID, userID, "AI 画图未配置 API Key（请联系管理员设置 ai_image_api_key）")
 		return true
 	}
 
@@ -67,7 +96,7 @@ func (a *App) handleAIImageCommand(rawMessage string, data map[string]any, messa
 		imageRef = "base64://" + result.B64JSON
 	}
 	if imageRef == "" {
-		msg := "AI 生图返回为空"
+		msg := "AI 画图返回为空"
 		if messageType == "group" && groupID > 0 {
 			a.bot.SendGroupMsgWithAtText(groupID, userID, msg)
 		} else {

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -119,6 +119,14 @@ type Config struct {
 	DailyRecommendGroups  []int64 `yaml:"daily_recommend_groups"`
 
 	MaxConcurrentDownloads int `yaml:"max_concurrent_downloads"`
+
+	AIImageEnabled   bool   `yaml:"ai_image_enabled"`
+	AIImageBaseURL   string `yaml:"ai_image_base_url"`
+	AIImageAPIKey    string `yaml:"ai_image_api_key"`
+	AIImageModel     string `yaml:"ai_image_model"`
+	AIImageSize      string `yaml:"ai_image_size"`
+	AIImageTimeout   int    `yaml:"ai_image_timeout_seconds"`
+	AIImageMaxRetries int   `yaml:"ai_image_max_retries"`
 }
 
 type App struct {
@@ -657,6 +665,24 @@ func fillDefaults(cfg *Config) {
 		} else {
 			cfg.CardUserID = 10000
 		}
+	}
+	if cfg.AIImageAPIKey == "" {
+		cfg.AIImageAPIKey = os.Getenv("AI_IMAGE_API_KEY")
+	}
+	if cfg.AIImageBaseURL == "" {
+		cfg.AIImageBaseURL = "https://api.openai.com/v1"
+	}
+	if cfg.AIImageModel == "" {
+		cfg.AIImageModel = "dall-e-3"
+	}
+	if cfg.AIImageSize == "" {
+		cfg.AIImageSize = "1024x1024"
+	}
+	if cfg.AIImageTimeout <= 0 {
+		cfg.AIImageTimeout = 120
+	}
+	if cfg.AIImageMaxRetries <= 0 {
+		cfg.AIImageMaxRetries = 3
 	}
 }
 
@@ -1214,6 +1240,10 @@ func (a *App) handleMessageEvent(data map[string]any) {
 		return
 	}
 	if a.handleAdminClaimCommand(rawMessage, messageType, groupID, userID) {
+		return
+	}
+
+	if a.handleAIImageCommand(rawMessage, data, messageType, groupID, userID) {
 		return
 	}
 
@@ -4270,6 +4300,10 @@ func helpMessage() string {
 		"15) /jm daily add|del <群号>：添加/删除推荐群（管理员）\n" +
 		"16) /jm daily now：立即发送每日推荐（管理员）\n" +
 		"16) /jm help：查看帮助\n\n" +
+		"【AI生图】\n" +
+		"1) image2 <提示词>：AI 文生图\n" +
+		"2) 引用图片后 image2 <提示词>：AI 图生图\n" +
+		"3) /image2 <提示词>：同上\n\n" +
 		"【哔咔漫画】\n" +
 		"1) /bika on|off：启用/关闭哔咔（管理员）\n" +
 		"2) /bika login <邮箱> <密码>：登录哔咔账号\n" +
@@ -4384,6 +4418,14 @@ func NewNapcatClient(url, token string, dryRun bool) *NapcatClient {
 func (c *NapcatClient) SendPrivateMessage(userID int64, message string) bool {
 	_, err := c.send("send_private_msg", map[string]any{"user_id": userID, "message": []map[string]any{{"type": "text", "data": map[string]any{"text": message}}}}, echo("private_text", userID), 10*time.Second)
 	return err == nil
+}
+
+func (c *NapcatClient) GetMsg(messageID int64) (map[string]any, error) {
+	resp, err := c.send("get_msg", map[string]any{"message_id": messageID}, echo("get_msg", messageID), 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	return mapGet(resp, "data"), nil
 }
 
 func (c *NapcatClient) GetImageURL(fileRef string) (string, error) {
@@ -4747,6 +4789,38 @@ func buildMarkdownCard(nickname, message string) string {
 
 func (c *NapcatClient) SendPrivateFile(cfg Config, userID int64, filePath string) bool {
 	return c.sendFile(cfg, "send_private_msg", map[string]any{"user_id": userID}, filePath)
+}
+
+func (c *NapcatClient) SendGroupMsgWithAtAndImage(groupID, userID int64, imageFile string) bool {
+	_, err := c.send("send_group_msg", map[string]any{
+		"group_id": groupID,
+		"message": []map[string]any{
+			{"type": "at", "data": map[string]any{"qq": userID}},
+			{"type": "image", "data": map[string]any{"file": imageFile}},
+		},
+	}, echo("group_img_at", groupID), 60*time.Second)
+	return err == nil
+}
+
+func (c *NapcatClient) SendPrivateMsgWithImage(userID int64, imageFile string) bool {
+	_, err := c.send("send_private_msg", map[string]any{
+		"user_id": userID,
+		"message": []map[string]any{
+			{"type": "image", "data": map[string]any{"file": imageFile}},
+		},
+	}, echo("private_img", userID), 60*time.Second)
+	return err == nil
+}
+
+func (c *NapcatClient) SendGroupMsgWithAtText(groupID, userID int64, text string) bool {
+	_, err := c.send("send_group_msg", map[string]any{
+		"group_id": groupID,
+		"message": []map[string]any{
+			{"type": "at", "data": map[string]any{"qq": userID}},
+			{"type": "text", "data": map[string]any{"text": text}},
+		},
+	}, echo("group_at_txt", groupID), 10*time.Second)
+	return err == nil
 }
 
 func (c *NapcatClient) SendGroupFile(cfg Config, groupID int64, filePath string) bool {

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -4300,10 +4300,12 @@ func helpMessage() string {
 		"15) /jm daily add|del <群号>：添加/删除推荐群（管理员）\n" +
 		"16) /jm daily now：立即发送每日推荐（管理员）\n" +
 		"16) /jm help：查看帮助\n\n" +
-		"【AI生图】\n" +
-		"1) image2 <提示词>：AI 文生图\n" +
-		"2) 引用图片后 image2 <提示词>：AI 图生图\n" +
-		"3) /image2 <提示词>：同上\n\n" +
+		"【AI画图】\n" +
+		"1) image on：开启画图功能（管理员）\n" +
+		"2) image off：关闭画图功能（管理员）\n" +
+		"3) image2 <提示词>：AI 文生图\n" +
+		"4) 引用图片后 image2 <提示词>：AI 图生图\n" +
+		"5) /image2 <提示词>：同上\n\n" +
 		"【哔咔漫画】\n" +
 		"1) /bika on|off：启用/关闭哔咔（管理员）\n" +
 		"2) /bika login <邮箱> <密码>：登录哔咔账号\n" +


### PR DESCRIPTION
## AI 画图插件

通过 OpenAI 兼容 API 实现 AI 图像生成，以同进程插件方式集成。

**注意：** 本分支基于 `fix-stable-comic-file-send`，包含其全部改动 + AI 画图。建议先合并 #6，再合并本 PR，或对本 PR 做 rebase。

### 功能
- `image on` / `image off`：管理员开关 AI 画图
- `image2 <提示词>`：根据文字生成图片
- **图生图**：回复带图片的消息发送 `image2 <提示词>`，自动引用回复的图片作为参考图
- 失败自动重试最多 3 次，全部失败才返回报错
- API Key 支持环境变量 `AI_IMAGE_API_KEY` 回退，避免写入配置文件
- 兼容任何 OpenAI `/v1/images/generations`（文生图）和 `/v1/images/edits`（图生图）API

### 实现
- `internal/aiimage/`：独立 API 客户端包（Config、GenerateImage、EditImage、重试逻辑）
- `internal/app/ai_image.go`：薄整合层（命令处理、图片提取、发送）
- `internal/app/main.go`：Config 新增 7 个字段 + fillDefaults 默认值 + 命令分发 + 帮助信息
- NapcatClient 新增 4 个方法：GetMsg、SendGroupMsgWithAtAndImage、SendPrivateMsgWithImage、SendGroupMsgWithAtText

### 设计原则
- 同进程插件式：只在 handleMessageEvent 加一个 if 判断分支，不碰核心逻辑
- 成功时 @用户 + 发送图片（不暴露提示词）；失败时 @用户 + 报错（不暴露提示词）
- 图片来源优先级：引用消息图片 > 当前消息图片 > 纯文生图